### PR TITLE
Refactor: Improve configuration, error handling, and CLI usability

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,22 +20,32 @@ pip install mistralai
 
 ## 使用方法
 
-1. 获取 Mistral AI API 密钥
-2. 修改 `pdf_ocr.py` 中的 API 密钥和 PDF 文件路径
-3. 运行脚本处理 PDF 文件
+1.  **设置环境变量**:
+    *   获取您的 Mistral AI API 密钥。
+    *   设置 `MISTRAL_API_KEY` 环境变量。例如，在 Linux 或 macOS 上：
+        ```bash
+        export MISTRAL_API_KEY="your_actual_api_key"
+        ```
+        在 Windows 上，您可以在 PowerShell 中使用:
+        ```powershell
+        $Env:MISTRAL_API_KEY="your_actual_api_key"
+        ```
+        或者通过系统属性设置。
 
-```python
-# 在 pdf_ocr.py 中设置
-API_KEY = "your_mistral_api_key"
-PDF_PATH = "your_pdf_file.pdf"
-
-# 然后运行脚本
-python pdf_ocr.py
-```
+2.  **运行脚本**:
+    *   使用以下命令运行脚本，将 `your_document.pdf` 替换为您的 PDF 文件的实际路径：
+        ```bash
+        python pdf_ocr.py your_document.pdf
+        ```
+    *   您可以选择使用 `-o` 或 `--output_dir` 参数指定自定义输出目录：
+        ```bash
+        python pdf_ocr.py your_document.pdf -o custom_output_folder
+        ```
+        如果未提供输出目录，结果将保存在名为 `ocr_results_[PDF文件名]` 的文件夹中，该文件夹将在脚本运行的目录中创建。
 
 ## 输出结果
 
-脚本将在工作目录下创建一个名为 `ocr_results_[PDF文件名]` 的文件夹，其中包含：
+脚本将根据指定的输出目录（或默认目录 `ocr_results_[PDF文件名]`）创建一个文件夹，其中包含：
 
 - `complete.md`: 包含所有页面内容的 Markdown 文件
 - `images/`: 保存 PDF 中提取出的所有图像的文件夹
@@ -43,7 +53,8 @@ python pdf_ocr.py
 
 ## 注意事项
 
-- 请确保 PDF 文件路径正确
-- API 密钥需要具有 OCR 功能的访问权限
+- 请确保提供的 PDF 文件路径正确且文件可访问。
+- API 密钥需要具有 OCR 功能的访问权限。
+- 如果指定的输出目录已存在，脚本仍会尝试在其中创建 `images` 子目录和 `complete.md` 文件。现有同名文件可能会被覆盖。
 
 

--- a/pdf_ocr.py
+++ b/pdf_ocr.py
@@ -2,8 +2,15 @@ from mistralai import Mistral
 from pathlib import Path
 import os
 import base64
+import sys
+import argparse
 from mistralai import DocumentURLChunk
 from mistralai.models import OCRResponse
+try:
+    from mistralai.exceptions import MistralAPIException, MistralConnectionException, MistralException
+except ImportError:
+    # Fallback if specific exceptions are not found
+    MistralAPIException = MistralConnectionException = MistralException = Exception
 
 def replace_images_in_markdown(markdown_str: str, images_dict: dict) -> str:
     for img_name, img_path in images_dict.items():
@@ -35,47 +42,111 @@ def save_ocr_results(ocr_response: OCRResponse, output_dir: str) -> None:
     with open(os.path.join(output_dir, "complete.md"), 'w', encoding='utf-8') as f:
         f.write("\n\n".join(all_markdowns))
 
-def process_pdf(pdf_path: str, api_key: str) -> None:
+def process_pdf(pdf_path: str, output_dir_arg: str = None) -> None:
+    # 获取 API Key
+    api_key = os.environ.get("MISTRAL_API_KEY")
+    if not api_key:
+        raise ValueError("MISTRAL_API_KEY 环境变量未设置。")
+
     # 初始化客户端
     client = Mistral(api_key=api_key)
     
     # 确认PDF文件存在
     pdf_file = Path(pdf_path)
     if not pdf_file.is_file():
+        # This check might be redundant if argparse handles file existence,
+        # but good for direct calls or future refactoring.
         raise FileNotFoundError(f"PDF文件不存在: {pdf_path}")
     
-    # 创建输出目录名称
-    output_dir = f"ocr_results_{pdf_file.stem}"
+    # 确定输出目录
+    if output_dir_arg:
+        output_dir = output_dir_arg
+    else:
+        output_dir = f"ocr_results_{pdf_file.stem}"
     
     # 上传并处理PDF
     print(f"正在上传文件: {pdf_file.name}...")
-    uploaded_file = client.files.upload(
-        file={
-            "file_name": pdf_file.stem,
-            "content": pdf_file.read_bytes(),
-        },
-        purpose="ocr",
-    )
-    print(f"文件已上传成功，文件ID: {uploaded_file.id}")
-    
+    try:
+        uploaded_file = client.files.upload(
+            file={
+                "file_name": pdf_file.stem,
+                "content": pdf_file.read_bytes(),
+            },
+            purpose="ocr",
+        )
+        print(f"文件已上传成功，文件ID: {uploaded_file.id}")
+    except FileNotFoundError: # Should be caught by pre-check, but good for robustness
+        print(f"错误: PDF文件 '{pdf_path}' 未找到。")
+        sys.exit(1)
+    except (MistralAPIException, MistralConnectionException) as e:
+        print(f"错误: 上传PDF文件时发生API或连接错误: {e}")
+        sys.exit(1)
+    except MistralException as e:
+        print(f"错误: 上传PDF文件时发生Mistral相关错误: {e}")
+        sys.exit(1)
+    except Exception as e:
+        print(f"错误: 上传PDF文件时发生未知错误: {e}")
+        sys.exit(1)
+
     print("正在获取签名URL...")
-    signed_url = client.files.get_signed_url(file_id=uploaded_file.id, expiry=1)
+    try:
+        signed_url = client.files.get_signed_url(file_id=uploaded_file.id, expiry=1)
+    except (MistralAPIException, MistralConnectionException) as e:
+        print(f"错误: 获取签名URL时发生API或连接错误: {e}")
+        sys.exit(1)
+    except MistralException as e:
+        print(f"错误: 获取签名URL时发生Mistral相关错误: {e}")
+        sys.exit(1)
+    except Exception as e:
+        print(f"错误: 获取签名URL时发生未知错误: {e}")
+        sys.exit(1)
     
     print("OCR处理中，请稍候...")
-    pdf_response = client.ocr.process(
-        document=DocumentURLChunk(document_url=signed_url.url), 
-        model="mistral-ocr-latest", 
-        include_image_base64=True
-    )
+    try:
+        pdf_response = client.ocr.process(
+            document=DocumentURLChunk(document_url=signed_url.url),
+            model="mistral-ocr-latest",
+            include_image_base64=True
+        )
+    except (MistralAPIException, MistralConnectionException) as e:
+        print(f"错误: OCR处理过程中发生API或连接错误: {e}")
+        sys.exit(1)
+    except MistralException as e:
+        print(f"错误: OCR处理过程中发生Mistral相关错误: {e}")
+        sys.exit(1)
+    except Exception as e:
+        print(f"错误: OCR处理过程中发生未知错误: {e}")
+        sys.exit(1)
     
     print("OCR处理已完成，正在保存结果...")
     # 保存结果
     save_ocr_results(pdf_response, output_dir)
     print(f"OCR处理完成。结果保存在: {output_dir}")
 
-if __name__ == "__main__":
-    # 使用示例
-    API_KEY  =  "你的密钥"
-    PDF_PATH  =  " zh.pdf "
+def main():
+    # API_KEY 将从环境变量 MISTRAL_API_KEY 读取 (process_pdf内处理)
     
-    process_pdf(PDF_PATH, API_KEY)
+    parser = argparse.ArgumentParser(description="使用 Mistral AI OCR 功能处理 PDF 文件。")
+    parser.add_argument("pdf_path", help="要处理的 PDF 文件的路径。")
+    parser.add_argument(
+        "-o", "--output_dir",
+        help="存储结果的输出目录。如果未提供，则默认为 'ocr_results_[PDF文件名]'。"
+    )
+
+    args = parser.parse_args()
+
+    try:
+        process_pdf(args.pdf_path, args.output_dir)
+    except FileNotFoundError as e:
+        # This primarily catches the FileNotFoundError from the pdf_file.is_file() check
+        # at the beginning of process_pdf if called directly or if argparse doesn't fully prevent it.
+        print(f"主程序错误: {e}")
+        sys.exit(1)
+    except ValueError as e: # For API key not set (raised from process_pdf)
+        print(f"主程序错误: {e}")
+        sys.exit(1)
+    # Note: Specific API errors inside process_pdf already call sys.exit(1),
+    # so they won't typically propagate to be caught here.
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This commit introduces several enhancements to the PDF OCR tool:

- **Configuration:**
    - The Mistral API key is now read from the `MISTRAL_API_KEY` environment variable, removing the need to hardcode it.
    - The input PDF file path is now a required command-line argument.
    - An optional command-line argument (`-o` or `--output_dir`) allows you to specify a custom output directory.

- **Error Handling:**
    - Added `try...except` blocks around Mistral API calls (`files.upload`, `files.get_signed_url`, `ocr.process`) to catch potential exceptions and provide user-friendly error messages. The script will exit gracefully if these critical operations fail.

- **CLI and Usability:**
    - Implemented a command-line interface using `argparse` for specifying the PDF path and output directory.
    - Updated `README.md` with new setup and usage instructions, including how to set the environment variable and use the CLI arguments.

- **Code Structure:**
    - Refactored the main execution logic into a `main()` function for better organization and readability.

These changes make the tool more robust, configurable, and easier to use from the command line.