### PR TITLE
I've increased the signed URL expiry time to 60 seconds.

### DIFF
--- a/pdf_ocr.py
+++ b/pdf_ocr.py
@@ -90,7 +90,7 @@ def process_pdf(pdf_path: str, output_dir_arg: str = None) -> None:
 
     print("正在获取签名URL...")
     try:
-        signed_url = client.files.get_signed_url(file_id=uploaded_file.id, expiry=1)
+        signed_url = client.files.get_signed_url(file_id=uploaded_file.id, expiry=60) # Increased expiry to 60 seconds
     except (MistralAPIException, MistralConnectionException) as e:
         print(f"错误: 获取签名URL时发生API或连接错误: {e}")
         sys.exit(1)


### PR DESCRIPTION
The previous expiry time of 1 second for the signed URL, which the Mistral OCR service uses to access the uploaded PDF, was too short and could lead to intermittent processing failures.

This change increases the expiry time to 60 seconds to provide a more reliable window for the OCR service to access the document, especially considering potential network latencies or service-side queuing.