### PR TITLE
Add web UI for multi-file OCR

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 运行此工具需要以下依赖项：
 
 ```bash
-pip install mistralai
+pip install mistralai flask
 ```
 
 ## 使用方法
@@ -42,6 +42,13 @@ pip install mistralai
         python pdf_ocr.py your_document.pdf -o custom_output_folder
         ```
         如果未提供输出目录，结果将保存在名为 `ocr_results_[PDF文件名]` 的文件夹中，该文件夹将在脚本运行的目录中创建。
+
+3.  **启动 Web UI**:
+    * 通过以下命令启动简易 Web 界面，可一次上传并处理多个 PDF 文件：
+        ```bash
+        python webui.py
+        ```
+    * 浏览器访问 `http://localhost:5000` 即可使用。上传的文件必须是 PDF，处理完成后会提供打包好的 ZIP 下载。
 
 ## 输出结果
 

--- a/webui.py
+++ b/webui.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from flask import Flask, request, render_template_string, send_file, after_this_request
 from werkzeug.utils import secure_filename
 
-from pdf_ocr import process_pdf
+from pdf_ocr import process_pdf, OCRProcessingError
 
 app = Flask(__name__)
 
@@ -49,8 +49,10 @@ def upload_and_ocr():
             try:
                 process_pdf(pdf_path, out_dir)
                 result_dirs.append(out_dir)
-            except Exception as e:
+            except (FileNotFoundError, ValueError, OCRProcessingError) as e:
                 errors.append(f"{filename}: {e}")
+            except Exception as e:
+                errors.append(f"{filename}: 未知错误 {e}")
 
         if not result_dirs:
             return {'errors': errors}, 400

--- a/webui.py
+++ b/webui.py
@@ -1,0 +1,72 @@
+import os
+import tempfile
+import zipfile
+import shutil
+from pathlib import Path
+from flask import Flask, request, render_template_string, send_file, after_this_request
+from werkzeug.utils import secure_filename
+
+from pdf_ocr import process_pdf
+
+app = Flask(__name__)
+
+HTML_FORM = """
+<!doctype html>
+<title>Mistral OCR WebUI</title>
+<h1>Upload PDF files for OCR</h1>
+<form method=post enctype=multipart/form-data>
+  <input type=file name=files multiple>
+  <input type=submit value='Start OCR'>
+</form>
+"""
+
+@app.route('/', methods=['GET', 'POST'])
+def upload_and_ocr():
+    if request.method == 'POST':
+        uploaded_files = request.files.getlist('files')
+        if not uploaded_files:
+            return 'No files uploaded', 400
+
+        work_dir = tempfile.mkdtemp(prefix='ocr_web_')
+        result_dirs = []
+        errors = []
+
+        @after_this_request
+        def cleanup(response):
+            shutil.rmtree(work_dir, ignore_errors=True)
+            return response
+
+        for f in uploaded_files:
+            if f.filename == '':
+                continue
+            filename = secure_filename(f.filename)
+            if not filename.lower().endswith('.pdf'):
+                errors.append(f"{filename}: not a PDF")
+                continue
+            pdf_path = os.path.join(work_dir, filename)
+            f.save(pdf_path)
+            out_dir = os.path.join(work_dir, f'ocr_results_{Path(filename).stem}')
+            try:
+                process_pdf(pdf_path, out_dir)
+                result_dirs.append(out_dir)
+            except Exception as e:
+                errors.append(f"{filename}: {e}")
+
+        if not result_dirs:
+            return {'errors': errors}, 400
+
+        zip_path = os.path.join(work_dir, 'results.zip')
+        with zipfile.ZipFile(zip_path, 'w') as zipf:
+            for d in result_dirs:
+                for root, _, files in os.walk(d):
+                    for file in files:
+                        file_path = os.path.join(root, file)
+                        arcname = os.path.relpath(file_path, work_dir)
+                        zipf.write(file_path, arcname)
+
+        return send_file(zip_path, as_attachment=True)
+    return render_template_string(HTML_FORM)
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=5000)
+


### PR DESCRIPTION
## Summary
- support Flask web interface to upload multiple PDFs
- mention Flask dependency and usage in README
- ensure web UI validates PDFs, captures OCR errors, and cleans up temp files

## Testing
- `python -m py_compile pdf_ocr.py webui.py`


------
https://chatgpt.com/codex/tasks/task_e_683fd4c0cbd483269ca96b02a0af5b6a